### PR TITLE
Fix setup issues & make API calls work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/Http/SymfonyAdapter.php
+++ b/Http/SymfonyAdapter.php
@@ -100,7 +100,7 @@ class SymfonyAdapter implements AdapterInterface, LoggerAwareInterface
         }
 
         try {
-            $response = $this->client->request($method, $path, ['base_uri' => $this->endpoint, 'headers' => ['Authorization' => "Bearer {$this->getAccessToken()}", 'Accept' => 'application/json',], 'json' => $data,]);
+            $response = $this->client->request(strtoupper($method), $path, ['base_uri' => $this->endpoint, 'headers' => ['Authorization' => "Bearer {$this->getAccessToken()}", 'Accept' => 'application/json',], 'json' => $data,]);
             $data = json_decode($response->getContent(), true);
             $this->log(LogLevel::INFO, 'Response data.', ['response' => $data]);
 

--- a/Tests/Http/SymfonyAdapterTest.php
+++ b/Tests/Http/SymfonyAdapterTest.php
@@ -54,7 +54,7 @@ class SymfonyAdapterTest extends TestCase
     {
         $symfony = $this->createSymfonyAdapter();
         $symfony->authorize('cli3ntId', 'clientS3cr3t');
-        $data = $symfony->action('GET', '/action/test');
+        $data = $symfony->action('get', '/action/test');
         $this->assertEquals('test', $data['test']);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "php": "^8.0",
         "ext-json": "*",
         "symfony/http-client": "^6.4",
         "psr/log": "^1|^2|^3"
@@ -29,5 +30,9 @@
         "psr-4": {
             "Enhavo\\Component\\CleverReach\\Tests\\": "Tests/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.0",
+        "symfony/panther": "^2.2"
     }
 }


### PR DESCRIPTION
I am a first-time user of this library, so if I misunderstood something please let me know 😉 

This small PR fixes several issues:

1. API calls are not working because of Symfony exception "Invalid HTTP method "get", only uppercase letters are accepted."
2. Dependencies for unit tests are not installed
3. Add minimum required PHP version
4. Add gitignore file